### PR TITLE
Fix for 'dirty' error caused by scroll notifications during layout

### DIFF
--- a/lib/src/scroll_shadow.dart
+++ b/lib/src/scroll_shadow.dart
@@ -63,14 +63,18 @@ class _ScrollShadowState extends State<ScrollShadow> {
 
   set reachedStart(final bool value) {
     if (_reachedStart == value) return;
-    setState(() => _reachedStart = value);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      setState(() => _reachedStart = value);
+    });
   }
 
   bool get reachedEnd => _reachedEnd;
 
   set reachedEnd(final bool value) {
     if (_reachedEnd == value) return;
-    setState(() => _reachedEnd = value);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      setState(() => _reachedEnd = value);
+    });
   }
 
   @override
@@ -186,7 +190,9 @@ class _ScrollShadowState extends State<ScrollShadow> {
 
   bool _handleNewMetrics(final ScrollMetrics metrics) {
     if (_axis != metrics.axis) {
-      setState(() => _axis = metrics.axis);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        setState(() => _axis = metrics.axis);
+      });
     }
     reachedStart = metrics.pixels <= metrics.minScrollExtent;
     reachedEnd = metrics.pixels >= metrics.maxScrollExtent;

--- a/lib/src/scroll_shadow.dart
+++ b/lib/src/scroll_shadow.dart
@@ -1,6 +1,8 @@
 /// [ScrollShadow] class
 library flutter_scroll_shadow;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 /// Wraps a scrollable child in `ScrollShadow`s.
@@ -63,7 +65,7 @@ class _ScrollShadowState extends State<ScrollShadow> {
 
   set reachedStart(final bool value) {
     if (_reachedStart == value) return;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    scheduleMicrotask(() {
       setState(() => _reachedStart = value);
     });
   }
@@ -72,7 +74,7 @@ class _ScrollShadowState extends State<ScrollShadow> {
 
   set reachedEnd(final bool value) {
     if (_reachedEnd == value) return;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    scheduleMicrotask(() {
       setState(() => _reachedEnd = value);
     });
   }
@@ -190,7 +192,7 @@ class _ScrollShadowState extends State<ScrollShadow> {
 
   bool _handleNewMetrics(final ScrollMetrics metrics) {
     if (_axis != metrics.axis) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
+      scheduleMicrotask(() {
         setState(() => _axis = metrics.axis);
       });
     }


### PR DESCRIPTION
Previously if the widget was rebuilt, (by calling a modal bottom sheet in my case), and a scroll notification happened during that rebuild, you would receive a dirty state error.  By moving the setStates to a microtask, it avoids this error.